### PR TITLE
Update badge page status and show/hide as status changes

### DIFF
--- a/clientapp/templates/pages/badge.html
+++ b/clientapp/templates/pages/badge.html
@@ -8,9 +8,7 @@
         <img src="/static/badge.png">
       </div>
       <h1>{{title}}</h1>
-      {% if status %}
-      <p>Status: {{status}}</p>
-      {% endif %}
+      <p class="status">Status: <span>{{status}}</span></p>
       <p>
         Flannel squid jean shorts banh mi Cosby sweater, Blue Bottle Tonx fixie ethical.
       </p>

--- a/clientapp/views/pages/badge.js
+++ b/clientapp/views/pages/badge.js
@@ -6,8 +6,15 @@ module.exports = HumanView.extend({
   classBindings: {
     'userFavorite': '.favorite-icon' 
   },
+  textBindings: {
+    'status': '.status span'
+  },
   render: function () {
     this.renderAndBind(this.model);
+    this.listenToAndRun(this.model, 'change:status', function (model) {
+      var hide = !this.model.status;
+      this.$('.status').toggleClass('hide', hide);
+    });
     return this;
   },
   events: {


### PR DESCRIPTION
Seems a bit weird for the status to show/hide as you toggle/untoggle a badge from the wishlist but we'll go with it for now.
