### PR TITLE
Refactor the editor to use backbone conventions

### DIFF
--- a/clientapp/modules/editor.js
+++ b/clientapp/modules/editor.js
@@ -102,7 +102,8 @@ function makePathwayItem(item) {
 
 module.exports = Backbone.View.extend({
   initialize: function (opts) {
-    if (!opts) throw new Error('need opts TODO specify which');
+    if (!(opts && opts.canvas && opts.columns && opts.requirements)) 
+      throw new Error('You must specify canvas, columns, and requirements options');
 
     Object.defineProperty(this, "columnCount", {
       get: function () { return world.columnCount; },

--- a/clientapp/modules/editor.js
+++ b/clientapp/modules/editor.js
@@ -1,204 +1,197 @@
-function makeMarker (col, row, grid) {
-  var r = 15;
-  var sides = 6;
-  var angle = 30;
-  var shape = new createjs.Shape();
-  shape.graphics.beginFill("#CCC").drawPolyStar(0, 0, r, sides, 0, angle);
-  shape.resize = function () {
-    var coords = grid.gridToPixel(col, row);
-    shape.x = coords.cx;
-    shape.y = coords.cy;
-    shape.setBounds(-coords.w/2, -coords.w/2, coords.w, coords.w);
-  };
-  shape.resize();
-  return shape;
-}
+var _ = require('underscore');
+var Backbone = require('backbone');
+Backbone.$ = window.$; // WHHHHHHYYYYYYYY?!
 
-function makeTile (model, grid) {
-  var width = grid.canvas.width / grid.columns;
-  var height = width;
+function World () { 
 
-  var container = new createjs.Container();
-  container.setBounds(0, 0, width, height);
+  Object.defineProperty(this, "columnWidth", {
+    get: function () { return this.canvasWidth / this.columnCount; },
+    set: function () { throw new Error('Cannot set columnWidth directly'); }
+  });
 
-  var rect = new createjs.Shape();
-  var margin = 10;
-  var corners = 10;
-  var rw = width - (2 * margin);
-  var rh = height - (2 * margin);
-  rect.graphics.beginFill("#EEE").drawRoundRect(margin, margin, rw, rh, corners);
-  rect.setBounds(0, 0, rw, rh);
-  container.addChild(rect);
-
-  var img = new createjs.Bitmap('/static/badge.png');
-
-  function scaleToMax (img, w, h) {
-    var imgBounds = img.getBounds();
-    var width = Math.min(imgBounds.width, w);
-    var height = Math.min(imgBounds.height, h);
-    var scale = Math.min(width / imgBounds.width, height / imgBounds.height);
-    img.scaleX = img.scaleY = scale;
-  }
-
-  var fontSize = 24;
-  var t = new createjs.Text(model.name, fontSize + "px 'Helvetica Neue', Helvetica, Arial, sans-serif");
-
-  img.image.onload = function drawBadge () {
-    var rBounds = rect.getBounds();
-    scaleToMax(img, rBounds.width, rBounds.height - (fontSize * 2));
-    imgBounds = img.getTransformedBounds();
-    img.x = margin + (rBounds.width / 2) - (imgBounds.width / 2);
-    img.y = margin + (rBounds.height / 2) - (imgBounds.height / 2) - (fontSize / 2);
-    container.addChild(img);
-
-    t.x = margin + (rBounds.width / 2) - (t.getBounds().width /2);
-    t.y = img.y + imgBounds.height;
-    container.addChild(t);
-
-    container.dispatchEvent('ready');
-  };
-
-  container.resize = function () {
-    var width = grid.canvas.width / grid.columns;
-    var height = width;
-    container.setBounds(0, 0, width, height);
-    var rw = width - (2 * margin);
-    var rh = height - (2 * margin);
-    rect.graphics.clear().beginFill("#EEE").drawRoundRect(margin, margin, rw, rh, corners);
-    rect.setBounds(0, 0, rw, rh);
-    var rBounds = rect.getBounds();
-    scaleToMax(img, rBounds.width, rBounds.height - (fontSize * 2));
-    imgBounds = img.getTransformedBounds();
-    img.x = margin + (rBounds.width / 2) - (imgBounds.width / 2);
-    img.y = margin + (rBounds.height / 2) - (imgBounds.height / 2) - (fontSize / 2);
-    t.x = margin + (rBounds.width / 2) - (t.getBounds().width /2);
-    t.y = img.y + imgBounds.height;
-    var coords = grid.gridToPixel(model.x, model.y);
-    container.x = coords.x;
-    container.y = coords.y;
-  };
-
-  var coords = grid.gridToPixel(model.x, model.y);
-  container.x = coords.x;
-  container.y = coords.y;
-  return container;
-}
-
-function Editor (opts) {
-  opts = opts || {};
-
-  var self = this;
-
-  self.canvas = opts.canvas;
-  self.stage = new createjs.Stage(self.canvas);
-  createjs.Touch.enable(self.stage, true, true);
-  self.columns = opts.columns;
-
-  self.allowRearrange = false;
-
-  self.rearrange = function (toggle) {
-    if (typeof toggle !== 'undefined') self.allowRearrange = !!toggle;
-    else self.allowRearrange = true;
-  };
-
-  if (opts.mode === 'edit') self.rearrange();
-
-  self.remove = function () {
-    createjs.Touch.disable(self.stage);
-  };
-
-  self.gridToPixel = function (gx, gy) {
+  this.gridToPixel = function gridToPixel (gx, gy) {
     if (typeof gx === 'object') {
       var obj = gx;
       gx = obj.x;
       gy = obj.y;
     }
-    var colW = this.canvas.width / this.columns;
-    var x = gx * colW;
-    var y = gy * colW;
+    var x = gx * this.columnWidth;
+    var y = gy * this.columnWidth;
     return {
       x: x,
       y: y,
-      w: colW,
-      cx: x + (colW / 2),
-      cy: y + (colW / 2),
-      bounds: [x, y, colW, colW]
+      w: this.columnWidth,
+      cx: x + (this.columnWidth / 2),
+      cy: y + (this.columnWidth / 2),
+      bounds: [x, y, this.columnWidth, this.columnWidth]
     };
   };
 
-  self.pixelToGrid = function (x, y) {
+  this.pixelToGrid = function pixelToGrid (x, y) {
     if (typeof x === 'object') {
       var obj = x;
       x = obj.x;
       y = obj.y;
     }
-    var colW = this.canvas.width / this.columns;
-    var col = Math.floor(x / colW);
-    var row = Math.floor(y / colW);
+    var col = Math.floor(x / this.columnWidth);
+    var row = Math.floor(y / this.columnWidth);
     return {
       x: col,
       y: row
     };
   };
 
-  self.redraw = function () {
-    self.render(self.models);
+  return this;
+}
+var world = new World();
+
+function makePathwayItem(item) {
+  var container = new createjs.Container();
+  container.model = item;
+  container.name = item.id;
+  var rect = new createjs.Shape();
+  var img = new createjs.Bitmap('/static/badge.png');
+  var title = new createjs.Text(item.name, "24px 'Helvetica Neue', Helvetica, Arial, sans-serif");
+  container.addChild(rect, img, title);
+
+  img.image.onload = function () {
+    container.layout();
+    container.dispatchEvent('ready'); 
   };
 
-  self.render = function (models) {
-    self.models = models;
-    self.stage.removeAllChildren();
+  function scaleToMax (img, w, h) {
+    var imgBounds = img.getBounds();
+    if (imgBounds) {
+      var width = Math.min(imgBounds.width, w);
+      var height = Math.min(imgBounds.height, h);
+      var scale = Math.min(width / imgBounds.width, height / imgBounds.height);
+      img.scaleX = img.scaleY = scale;
+    }
+    return img.getTransformedBounds();
+  }
 
-    var maxRow = 0;
-    if (models.length) {
-      models.forEach(function (model) {
-        maxRow = Math.max(maxRow, model.y);
-        var tile = makeTile(model, self);
-        tile.on('ready', function () {
-          self.stage.addChild(tile);
-          self.stage.update();
-        });
+  container.layout = function () {
+    var width = world.columnWidth;
+    var height = width;
+    container.setBounds(0, 0, width, height);
 
-        tile.on('pressmove', function (evt) {
-          if (self.allowRearrange) {
-            var tile = this;
-            var coords = self.gridToPixel(self.pixelToGrid(self.stage.globalToLocal(evt.stageX, evt.stageY)));
-            tile.x = coords.x;
-            tile.y = coords.y;
-            self.stage.update();
-            evt.nativeEvent.preventDefault();
-          }
-        });
-      });
+    var margin = 10;
+    var corners = 10;
+    var rw = width - (2 * margin);
+    var rh = height - (2 * margin);
+    rect.graphics.clear().beginFill("#EEE")
+      .drawRoundRect(margin, margin, rw, rh, corners);
+    rect.setBounds(0, 0, rw, rh);
+
+    var imgBounds = scaleToMax(img, rw, rh - (24 * 2));
+    if (imgBounds) {
+      img.x = margin + (rw / 2) - (imgBounds.width / 2);
+      img.y = margin + (rh / 2) - (imgBounds.height / 2) - (24 / 2);
+
+      title.x = margin + (rw / 2) - (title.getBounds().width /2);
+      title.y = img.y + imgBounds.height;
     }
 
-    for (var row = 0; row <= maxRow + 2; row++) {
-      for (var col = 0; col < self.columns; col++) {
-        var m = new makeMarker(col, row, self);
-        self.stage.addChild(m);
-      }
-    }
-
-    self.stage.update();
+    var coords = world.gridToPixel(item.x, item.y);
+    container.x = coords.x;
+    container.y = coords.y;
   };
 
-  self.resize = function () {
-    for (var idx = 0; idx < self.stage.getNumChildren(); idx++) {
-      var child = self.stage.getChildAt(idx);
-      if (child.resize) child.resize();
-    }
-    self.stage.update();
-  };
-
-  self.stage.on('tickstart', function () {
-    self.sizeCanvasToStageHeight();
-  });
-
-  self.sizeCanvasToStageHeight = function () {
-    self.stage.canvas.height = self.stage.getTransformedBounds().height;
-  };
-
-  return self;
+  return container;
 }
 
-module.exports = Editor;
+module.exports = Backbone.View.extend({
+  initialize: function (opts) {
+    if (!opts) throw new Error('need opts TODO specify which');
+
+    Object.defineProperty(this, "columnCount", {
+      get: function () { return world.columnCount; },
+      set: function (val) { world.columnCount = val; }
+    });
+    world.canvasWidth = opts.canvas.width;
+    world.columnCount = opts.columns;
+
+    _.extend(this, opts);
+
+    this.stage = new createjs.Stage(this.canvas);
+    createjs.Touch.enable(this.stage, true, true);
+
+    var gridLayer = this.gridLayer = new createjs.Container();
+    this.stage.addChild(this.gridLayer);
+
+    this.maxRow = 0;
+    this.requirements.forEach(function (req) {
+      this.addBadge(req);
+    }.bind(this));
+
+    this.listenTo(this.requirements, "add", this.addBadge);
+
+    this.listenTo(this.requirements, "remove", function (req) {
+      if (req.id) {
+        var item = this.stage.getChildByName(req.id);
+        this.stage.removeChild(item);
+        this.refresh();
+      }
+    });
+
+    var editor = this;
+    gridLayer.layout = function () {
+      this.removeAllChildren();
+      for (var row = 0; row <= editor.maxRow + 2; row++) {
+        for (var col = 0; col < world.columnCount; col++) {
+          var coords = world.gridToPixel(col, row);
+          var hex = new createjs.Shape();
+          hex.graphics.beginFill("#CCC")
+            .drawPolyStar(0, 0, 15, 6, 0, 30);
+          hex.x = coords.cx;
+          hex.y = coords.cy;
+          hex.setBounds(-coords.w/2, -coords.w/2, coords.w, coords.w);
+          this.addChild(hex);
+        }
+      } 
+    };
+
+    this.layout();
+  },
+  addBadge: function (model) {
+    this.maxRow = Math.max(this.maxRow, model.y);
+    var item = makePathwayItem(model);
+    item.on('ready', function () {
+      this.stage.addChild(item); 
+      this.refresh();
+    }, this);
+    if (this.rearrangeable()) {
+      item.on('pressmove', function (evt) {
+        var coords = world.pixelToGrid(this.stage.globalToLocal(evt.stageX, evt.stageY));
+        item.model.x = coords.x;
+        item.model.y = coords.y;
+        evt.nativeEvent.preventDefault();
+        this.refresh();
+      }, this);
+    }
+  },
+  rearrangeable: function () {
+    return this.mode && (this.mode === 'edit');
+  },
+  layout: function () {
+    world.canvasWidth = this.stage.canvas.width;
+    this.stage.children.forEach(function (child) {
+      if (child.layout) child.layout();
+    });
+  },
+  render: function () {
+    this.stage.canvas.height = this.stage.getTransformedBounds().height;
+    this.stage.update();
+    return this;
+  },
+  refresh: function () {
+    this.layout();
+    this.render();
+  },
+  remove: function () {
+    createjs.Touch.disable(this.stage);
+    this.$el.remove();
+    this.stopListening();
+    return this;
+  }
+});

--- a/clientapp/modules/editor.js
+++ b/clientapp/modules/editor.js
@@ -48,6 +48,7 @@ var world = new World();
 function makePathwayItem(item) {
   var container = new createjs.Container();
   container.model = item;
+  console.log('naming', container.id, item.id);
   container.name = item.id;
   var rect = new createjs.Shape();
   var img = new createjs.Bitmap('/static/badge.png');
@@ -128,8 +129,10 @@ module.exports = Backbone.View.extend({
     this.listenTo(this.requirements, "add", this.addBadge);
 
     this.listenTo(this.requirements, "remove", function (req) {
+      console.log(arguments);
       if (req.id) {
         var item = this.stage.getChildByName(req.id);
+        console.log('removing', req.id, item.name);
         this.stage.removeChild(item);
         this.refresh();
       }

--- a/clientapp/views/includes/editor.js
+++ b/clientapp/views/includes/editor.js
@@ -14,12 +14,9 @@ module.exports = HumanView.extend({
     this.editor = new Editor({
       columns: 3,
       canvas: this.el,
-      mode: this.mode
+      mode: this.mode,
+      requirements: this.collection
     });
-    this.editor.render(this.collection.models);
-    this.collection.on('sync', function () {
-      this.editor.render(this.collection.models);
-    }.bind(this));
     return this;
   },
   remove: function () {

--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -1,0 +1,3 @@
+# Examples
+
+From the project root run ```node tests/examples/server``` and navigate to http://localhost:3000/editor.html.

--- a/tests/examples/editor.html
+++ b/tests/examples/editor.html
@@ -42,48 +42,55 @@
             </div>
           </div>
         </div>
+        <div class="row">
+          <div class="medium-6 columns">
+            <div class="row">
+              <div class="small-3 columns">
+                <label class="right inline">Add:</label>
+              </div>
+              <div class="small-9 columns">
+                <div class="row collapse">
+                  <div class="small-1 columns">
+                    <span class="prefix">x:</span>
+                  </div>
+                  <div class="small-2 columns">
+                    <input type="text" value="0" name="add-x" id="add-x" />
+                  </div>
+                  <div class="small-1 small-offset-1 columns">
+                    <span class="prefix">y:</span>
+                  </div>
+                  <div class="small-2 columns">
+                    <input type="text" value="0" name="add-y" id="add-y" />
+                  </div>
+                  <div class="small-4 small-offset-1 columns">
+                    <button id="add">Add</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="medium-6 columns">
+            <div class="row">
+              <div class="small-3 columns">
+                <label class="right inline">Remove:</label>
+              </div>
+              <div class="small-4 columns">
+                <input type="text" placeholder="ID" name="remove-id" id="remove-id" />
+              </div>
+              <div class="small-5 columns">
+                <button id="remove">Remove</button>
+              </div>
+            </div>
+          </div>
+        </div>
       </fieldset>
     </div>
-    <div class="small-12 columns">
+    <div class="small-12 columns" id="canvas-container">
       <canvas id="canvas" width=1000></canvas>
     </div>
   </div>
   <script src="/bower_components/jquery/dist/jquery.min.js"></script>
   <script src="/bower_components/easeljs/lib/easeljs-0.7.1.min.js"></script>
-  <script src="/modules.js"></script>
-  <script>
-  var Editor = require('editor');
-
-  var editor = new Editor({
-    columns: 3,
-    canvas: document.getElementById('canvas'),
-    mode: 'edit'
-  });
-
-  editor.render([
-    { x: 0, y: 0, name: 'hi there'},
-    { x: 1, y: 0, name: 'hi there'},
-    { x: 2, y: 1, name: 'hi there'}
-  ]);
-
-  $(window).bind('resize', function () {
-    if ($('[name="resize"]:checked').val() === 'redraw') {
-      $('#canvas').attr('width', $('body').width());
-      editor.resize();
-    }
-  });
-  $('[name="resize"]').change(function () {
-    $('#canvas').attr('width', $('body').width());
-    editor.resize();
-  });
-  $('#num-columns').keyup(function () {
-    var n = parseInt($(this).val());
-    if (n) {
-      editor.columns = n;
-      editor.redraw();
-    }
-  });
-
-  </script>
+  <script src="/editor.js"></script>
 </body>
 </html>

--- a/tests/examples/editor.js
+++ b/tests/examples/editor.js
@@ -13,10 +13,10 @@ window.reqs.add = function (item) {
   this.trigger('add', item);
 };
 window.reqs.remove = function (id) {
-  var idx = _.findWhere(reqs, {id: id}); 
-  if (idx) {
-    var items = this.splice(idx, 1);
-    this.trigger('remove', items[0]);
+  var item = _.findWhere(reqs, {id: id}); 
+  if (item) {
+    this.splice(reqs.indexOf(item), 1);
+    this.trigger('remove', item);
   }
 };
 
@@ -63,5 +63,6 @@ $('#add').click(function () {
 
 $('#remove').click(function () {
   var id = parseInt($('#remove-id').val());
+  console.log('removing', id);
   if (id) reqs.remove(id);
 });

--- a/tests/examples/editor.js
+++ b/tests/examples/editor.js
@@ -1,0 +1,67 @@
+var Editor = require('editor');
+var _ = require('underscore');
+var Backbone = require('backbone');
+
+window.reqs = _.extend([
+  { x: 0, y: 0, name: 'ID 1', id:1},
+  { x: 1, y: 0, name: 'ID 2', id:2},
+  { x: 2, y: 1, name: 'ID 3', id:3}
+], Backbone.Events);
+var nextId = 4;
+window.reqs.add = function (item) {
+  this.push(item);
+  this.trigger('add', item);
+};
+window.reqs.remove = function (id) {
+  var idx = _.findWhere(reqs, {id: id}); 
+  if (idx) {
+    var items = this.splice(idx, 1);
+    this.trigger('remove', items[0]);
+  }
+};
+
+var editor = new Editor({
+  columns: 3,
+  canvas: document.getElementById('canvas'),
+  mode: 'edit',
+  requirements: reqs
+});
+
+editor.render();
+
+$(window).bind('resize', function () {
+  if ($('[name="resize"]:checked').val() === 'redraw') {
+    $('#canvas').attr('width', $('#canvas-container').width());
+    editor.refresh();
+  }
+});
+
+$('[name="resize"]').change(function () {
+  $('#canvas').attr('width', $('#canvas-container').width());
+  editor.refresh();
+});
+
+$('#num-columns').keyup(function () {
+  var n = parseInt($(this).val());
+  if (n) {
+    editor.columnCount = n;
+    editor.refresh();
+  }
+});
+
+$('#add').click(function () {
+  var id = nextId++;
+  var x = $('#add-x').val();
+  var y = $('#add-y').val();
+  reqs.add({
+    id: id,
+    name: 'ID ' + id,
+    x: x,
+    y: y
+  });
+});
+
+$('#remove').click(function () {
+  var id = parseInt($('#remove-id').val());
+  if (id) reqs.remove(id);
+});


### PR DESCRIPTION
Refactor of the editor module to make it make more sense.

This separates the building of the scene graph from the size-and-column-count constrained task of laying out the visual elements more clearly, and allows the graph to be re-layed out on demand. 

It also now assumes the incoming pathway requirements operate like a Backbone collection in terms of basic events (`add` and `remove`) and updates the scene graph appropriately. No more "wipe everything and start over" approach! I also made the editor extend Backbone.View just because I'm getting used to the associated conventions and felt it helped organize the code. `editor.js` is still in the modules folder though because it should continue to operate as a fairly stand-alone thing if possible.

Additionally, the editor example page shows off the add/remove functionality.

TL;DR the code makes more sense now :tada:
