### PR TITLE
Use the nunjucks browser build appropriately, instead of browserifying

### DIFF
--- a/clientapp/index.js
+++ b/clientapp/index.js
@@ -23,7 +23,8 @@ module.exports = function (app, config) {
       path.join(__dirname, '../bower_components/foundation/js/foundation/foundation.js'),
       path.join(__dirname, '../bower_components/foundation/js/foundation/foundation.dropdown.js'),
       path.join(__dirname, '../bower_components/foundation/js/foundation/foundation.accordion.js'),
-      path.join(__dirname, '../bower_components/easeljs/lib/easeljs-0.7.1.min.js')
+      path.join(__dirname, '../bower_components/easeljs/lib/easeljs-0.7.1.min.js'),
+      path.join(__dirname, '../node_modules/nunjucks/browser/nunjucks-slim.js')
     ],
     stylesheets: [
       path.join(__dirname, 'build/normalize.css'),

--- a/clientapp/modules/templates.js
+++ b/clientapp/modules/templates.js
@@ -1,4 +1,3 @@
-var nunjucks = require('nunjucks');
 var templates = require('../build/precompiled.js');
 var path = require('path');
 
@@ -15,5 +14,5 @@ Object.keys(window.nunjucksPrecompiled).forEach(function (name) {
     if (!obj[step]) obj[step] = {};
     obj = obj[step];
   });
-  obj[methodName] = nunjucks.render.bind(nunjucks, name);
+  obj[methodName] = window.nunjucks.render.bind(nunjucks, name);
 });


### PR DESCRIPTION
Nunjucks 1.0.2 isn't browserify-able, so doing it this way means we can continue to use the latest nunjucks.
