### PR TITLE
Change user id as a number to _id as string

### DIFF
--- a/app/google-data.js
+++ b/app/google-data.js
@@ -8,6 +8,7 @@ const DataStore = require('nedb');
 
 const Achievements = new DataStore();
 const Requirements = new DataStore();
+const Favorites = new DataStore();
 
 function log () { if (config('DEV', false)) console.log.apply(null, arguments); }
 
@@ -84,7 +85,8 @@ function processSpreadsheet(spreadsheet, cb) {
 
     cb(null, {
       achievements: Achievements,
-      requirements: Requirements
+      requirements: Requirements,
+      favorites: Favorites
     });
   });
 }

--- a/clientapp/models/achievements.js
+++ b/clientapp/models/achievements.js
@@ -10,7 +10,7 @@ module.exports = Backbone.Collection.extend({
   model: Achievement,
   url: function () {
     if (window.app.currentUser.loggedIn && this.source) {
-      var uid = window.app.currentUser.id;
+      var uid = window.app.currentUser._id;
       return '/api/user/' + uid + '/' + this.source;
     }
     else {

--- a/clientapp/models/pledged.js
+++ b/clientapp/models/pledged.js
@@ -6,7 +6,7 @@ module.exports = HumanModel.define({
       type: 'string'
     },
     userId: {
-      type: 'number'
+      type: 'string'
     },
     cloneId: {
       type: 'string'

--- a/clientapp/models/user.js
+++ b/clientapp/models/user.js
@@ -4,9 +4,12 @@ module.exports = HumanModel.define({
   initialize: function (opts) {
     if (opts === null) this.setLoggedOut();
   },
+  idAttribute: '_id',
   url: '/api/user',
   props: {
-    id: ['number'],
+    _id: {
+      type: 'string'
+    },
     email: ['string']
   },
   derived: {

--- a/clientapp/router.js
+++ b/clientapp/router.js
@@ -90,7 +90,7 @@ module.exports = Backbone.Router.extend({
   showEditor: function (id) {
     var pledged = new Pledged({
       _id: id,
-      userId: window.app.currentUser.id
+      userId: window.app.currentUser._id
     });
     var requirements = new Requirements({
       parentId: pledged._id

--- a/clientapp/views/pages/pathway.js
+++ b/clientapp/views/pages/pathway.js
@@ -22,7 +22,7 @@ module.exports = HumanView.extend({
   pledge: function (evt) {
     if (window.app.currentUser.loggedIn) {
       var pledged = new Pledged({
-        userId: window.app.currentUser.id,
+        userId: window.app.currentUser._id,
         cloneId: this.model._id
       });
       pledged.save().done(function (model, status, xhr) {

--- a/tests/app/dummy-api.test.js
+++ b/tests/app/dummy-api.test.js
@@ -92,7 +92,7 @@ describe('Dummy API', function () {
     it('should decorate with favorites when logged in', function (done) {
       var server = api.createServer();
       var app = express();
-      app.use(setUser({id: 1}));
+      app.use(setUser({_id: 'a1'}));
       app.use(server);
       request(app)
         .get('/achievement')
@@ -167,7 +167,7 @@ describe('Dummy API', function () {
         var id = this.id;
         var fav = this.achievement.favorite;
         var app = express();
-        app.use(setUser({id: 1}));
+        app.use(setUser({_id: 'a1'}));
         app.use(this.server);
         request(app)
           .patch('/' + name + '/' + id)
@@ -302,10 +302,10 @@ describe('Dummy API', function () {
   describe('GET /user/:id/earned', function () {
     it('should return an empty list for now', function (done) {
       var app = express();
-      app.use(setUser({id: 1}));
+      app.use(setUser({_id: 'a1'}));
       app.use(api.createServer());
       request(app)
-        .get('/user/1/earned')
+        .get('/user/a1/earned')
         .expect(200)
         .expect('Content-Type', /json/)
         .expect([])
@@ -317,7 +317,7 @@ describe('Dummy API', function () {
     it('should return favorited achievements', function (done) {
       var fixture = Fixture({
         favorites: [
-          {userId: 1, achievementIdx: 0, favorite: true}
+          {userId: 'a1', achievementIdx: 0, favorite: true}
         ],
         achievements: [
           {title: "My achievement"}
@@ -325,10 +325,10 @@ describe('Dummy API', function () {
       });
       var server = api.createServer({dataGenerator: fixture});
       var app = express();
-      app.use(setUser({id: 1}));
+      app.use(setUser({_id: 'a1'}));
       app.use(server);
       request(app)
-        .get('/user/1/favorite')
+        .get('/user/a1/favorite')
         .expect(200)
         .expect('Content-Type', /json/)
         .expect(function (res) {
@@ -344,16 +344,16 @@ describe('Dummy API', function () {
       var server = api.createServer({
         dataGenerator: Fixture({
           achievements: [
-            {title: "My pledged", userId: 1},
-            {title: "Someone else's pledged", userId: 2}
+            {title: "My pledged", userId: 'a1'},
+            {title: "Someone else's pledged", userId: 'a2'}
           ]
         })
       });
       var app = express();
-      app.use(setUser({id: 1}));
+      app.use(setUser({_id: 'a1'}));
       app.use(server);
       request(app)
-        .get('/user/1/pledged')
+        .get('/user/a1/pledged')
         .expect(200)
         .expect('Content-Type', /json/)
         .expect(function (res) {
@@ -368,23 +368,23 @@ describe('Dummy API', function () {
     it('should pledge a clone of a pathway', function (done) {
       var fixture = Fixture({
         achievements: [
-          {title: "A pathway", userId: 2}
+          {title: "A pathway", userId: 'a2'}
         ]
       });
       fixture(function (err, data, fixtures) {
         var server = api.createServer({dataGenerator: function(cb) { cb(null, data); }});
         var app = express();
-        app.use(setUser({id: 1}));
+        app.use(setUser({_id: 'a1'}));
         app.use(server);
         request(app)
-          .post('/user/1/pledged')
+          .post('/user/a1/pledged')
           .send({cloneId: fixtures.achievements[0]._id})
           .expect(200)
           .expect('Content-Type', /json/)
           .expect(function (res) {
             res.body.should.be.an.Object;
             res.body.title.should.equal("A pathway");
-            res.body.userId.should.equal(1);
+            res.body.userId.should.equal('a1');
             res.body._id.should.not.equal(fixtures.achievements[0]._id);
           })
           .end(done);
@@ -394,7 +394,7 @@ describe('Dummy API', function () {
     it('should make clone the newest achievement', function (done) {
       var server = api.createServer();
       var app = express();
-      app.use(setUser({id: 1}));
+      app.use(setUser({_id: 'a1'}));
       app.use(server);
       request(app)
         .get('/achievement')
@@ -404,7 +404,7 @@ describe('Dummy API', function () {
           if (err) return done(err);    
           var latest = res.body[0];
           request(app)
-            .post('/user/1/pledged')
+            .post('/user/a1/pledged')
             .send({cloneId: latest._id})
             .expect(200)
             .expect(function (res) {
@@ -429,20 +429,20 @@ describe('Dummy API', function () {
   describe('GET /user/:id/pledged/:pid', function () {
     it('should return pledged pathway', function (done) {
       Fixture({
-        achievements: [{title: "A pathway", userId: 1}]
+        achievements: [{title: "A pathway", userId: 'a1'}]
       })(function (err, data, fixtures) {
         var server = api.createServer({dataGenerator: function(cb) { cb(null, data); }});
         var app = express();
-        app.use(setUser({id: 1}));
+        app.use(setUser({_id: 'a1'}));
         app.use(server);
         request(app)
-          .get('/user/1/pledged/' + fixtures.achievements[0]._id)
+          .get('/user/a1/pledged/' + fixtures.achievements[0]._id)
           .expect(200)
           .expect('Content-Type', /json/)
           .expect(function (res) {
             res.body.should.be.an.Object;
             res.body.title.should.equal("A pathway");
-            res.body.userId.should.equal(1);
+            res.body.userId.should.equal('a1');
           })
           .end(done);
       });
@@ -452,14 +452,14 @@ describe('Dummy API', function () {
   describe('PUT /user/:id/pledged/:pid', function () {
     it('should edit pledged pathway', function (done) {
       Fixture({
-        achievements: [{title: "Original", userId: 1}]
+        achievements: [{title: "Original", userId: 'a1'}]
       })(function (err, data, fixtures) {
         var server = api.createServer({dataGenerator: function(cb) { cb(null, data); }});
         var app = express();
-        app.use(setUser({id: 1}));
+        app.use(setUser({_id: 'a1'}));
         app.use(server);
         request(app)
-          .put('/user/1/pledged/' + fixtures.achievements[0]._id)
+          .put('/user/a1/pledged/' + fixtures.achievements[0]._id)
           .send({title: "New", description: "Desc"})
           .expect(200)
           .expect('Content-Type', /json/)
@@ -467,7 +467,7 @@ describe('Dummy API', function () {
           .end(function (err) {
             if (err) return done(err);
             request(server)
-              .get('/user/1/pledged/' + fixtures.achievements[0]._id)
+              .get('/user/a1/pledged/' + fixtures.achievements[0]._id)
               .expect(200)
               .expect(function (res) {
                 res.body.should.be.an.Object;

--- a/tests/clientapp/achievements.test.js
+++ b/tests/clientapp/achievements.test.js
@@ -76,11 +76,11 @@ describe('Achievements', function () {
       app: {
         currentUser: {
           loggedIn: true,
-          id: 1
+          _id: 'a1'
         }
       }
     };
     var c = new Achievements([], {source: Achievements.BACKPACK});
-    c.url().should.equal('/api/user/1/earned');
+    c.url().should.equal('/api/user/a1/earned');
   });
 });

--- a/tests/clientapp/user-model.test.js
+++ b/tests/clientapp/user-model.test.js
@@ -4,7 +4,7 @@ var User = require('../../clientapp/models/user');
 describe('user clientside model', function () {
   it('should init to unknown state', function () {
     var user = new User();
-    should.strictEqual(user.id, undefined);
+    should.strictEqual(user._id, undefined);
     should.strictEqual(user.email, undefined);
     should.strictEqual(user.loggedInUser, undefined);
     user.loggedIn.should.equal(false);
@@ -14,7 +14,7 @@ describe('user clientside model', function () {
 
   it('should init to logged out state', function () {
     var user = new User(null);
-    should.strictEqual(user.id, undefined);
+    should.strictEqual(user._id, undefined);
     should.strictEqual(user.email, null);
     should.strictEqual(user.loggedInUser, null);
     user.loggedIn.should.equal(false);
@@ -23,8 +23,8 @@ describe('user clientside model', function () {
   });
 
   it('should init to logged in state', function () {
-    var user = new User({email: 'hi@example.org', id: 123});
-    user.id.should.equal(123);
+    var user = new User({email: 'hi@example.org', _id: '123'});
+    user._id.should.equal('123');
     user.email.should.equal('hi@example.org');
     user.loggedInUser.should.equal('hi@example.org');
     user.loggedIn.should.equal(true);
@@ -32,7 +32,7 @@ describe('user clientside model', function () {
   });
 
   it('should log out', function () {
-    var user = new User({email: 'hi@example.org', id: 123});
+    var user = new User({email: 'hi@example.org', _id: '123'});
     user.setLoggedOut();
     should.strictEqual(user.email, null);
     should.strictEqual(user.loggedInUser, null);
@@ -41,7 +41,7 @@ describe('user clientside model', function () {
 
   it('should log in', function () {
     var user = new User(null);
-    user.setLoggedIn({email: 'hi@mockmyid.com', id: 123});
+    user.setLoggedIn({email: 'hi@mockmyid.com', _id: '123'});
     user.email.should.equal('hi@mockmyid.com');
     user.loggedInUser.should.equal('hi@mockmyid.com');
     user.loggedIn.should.equal(true);


### PR DESCRIPTION
This was kind of annoying. Nedb wants the id to be `_id` as a string whereas neo4j had `id` as a number, so I've updated it throughout. This inconsistency was causing things like favorites not to work.
