### PR TITLE
Make 5 columns the editor default; also check columns query param

### DIFF
--- a/clientapp/views/includes/editor.js
+++ b/clientapp/views/includes/editor.js
@@ -4,6 +4,7 @@ var RequirementView = require('./requirement');
 var _ = require('underscore');
 var Editor = require('editor');
 var UndoManager = require('backbone-undo');
+var query = require('query-param-getter');
 
 module.exports = HumanView.extend({
   template: templates.includes.editor,
@@ -24,7 +25,7 @@ module.exports = HumanView.extend({
   render: function () {
     this.renderAndBind({showControls: this.mode === "edit"});
     this.editor = new Editor({
-      columns: 3,
+      columns: query('columns') || 5,
       canvas: this.$('canvas')[0],
       mode: this.mode,
       requirements: this.collection


### PR DESCRIPTION
Shows 5 columns in the editor by default, or whatever number of columns is specified by adding `?columns=10` to get 10 columns, for example.

<!---
@huboard:{"order":241.875,"custom_state":""}
-->
