### PR TITLE
Link to pledged if pathway is pledged by logged in user

### DIFF
--- a/clientapp/models/achievement.js
+++ b/clientapp/models/achievement.js
@@ -55,6 +55,9 @@ module.exports = HumanModel.define({
     },
     imgSrc: {
       type: 'string'
+    },
+    userId: {
+      type: 'string'
     }
   },
   derived: {

--- a/clientapp/models/achievement.js
+++ b/clientapp/models/achievement.js
@@ -81,6 +81,13 @@ module.exports = HumanModel.define({
       fn: function () {
         return this.imgSrc ? this.imgSrc : DEFAULT_IMG[this.type];
       }
+    },
+    creatorDisplay: {
+      deps: ['creator'],
+      fn: function () {
+        var user = window.app.currentUser;
+        return (user.loggedIn && user._id === this.userId) ? "You" : this.creator;
+      }
     }
   }
 });

--- a/clientapp/templates/includes/achievement.html
+++ b/clientapp/templates/includes/achievement.html
@@ -17,7 +17,7 @@
     </div>
     <div class="data">
       <h5 class="data-badge-title">{{title}}</h5>
-      <h5 class="data-created-by">Created by {{creator}}</h5>
+      <h5 class="data-created-by">Created by {{creatorDisplay}}</h5>
       {% for tag in tags %}
         <a class="label achievement-tag js-tag" data-tag="{{tag}}">#{{tag}}</a>
       {% endfor %}

--- a/clientapp/views/includes/achievement.js
+++ b/clientapp/views/includes/achievement.js
@@ -24,7 +24,10 @@ module.exports = HumanView.extend({
   },
   navToItem: function (evt) {
     var item = this.model;
-    var url = util.format('%s/%s', item.type, item._id);
+    var type = item.type;
+    if (window.app.currentUser.loggedIn && item.userId && item.userId === window.app.currentUser._id)
+      type = "pledged";
+    var url = util.format('%s/%s', type, item._id);
     app.router.navigateTo(url, item);
     evt.preventDefault();
     evt.stopPropagation();


### PR DESCRIPTION
Now if you click on a pathway that you created by pledging another, you'll go straight to the edit screen instead of being offered to re-pledge it. However, if you clicked someone else's pathway that you pledged before, you'll still be able to re-pledge that one, which seemed to make sense to me.
