### PR TITLE
Pull real stats on dashboard page

### DIFF
--- a/app/dummy-api.js
+++ b/app/dummy-api.js
@@ -311,6 +311,19 @@ function createApp(opts) {
     });
   });
 
+  app.get('/user/:uid/stats', function (req, res, next) {
+    var id = req.params.uid;
+
+    async.parallel({
+      earned: appData.earned.count.bind(appData.earned, {userId: id}),
+      favorited: appData.favorites.count.bind(appData.favorites, {userId: id}),
+      pledged: appData.achievements.count.bind(appData.achievements, {userId: id})
+    }, function (err, results) {
+      if (err) throw err;
+      return res.json(results);
+    });
+  });
+
   app.get('/image/:id', function (req, res, next) {
     var id = req.params.id;
     appData.achievements.findOne({_id: id}, function (err, doc) {

--- a/clientapp/models/stats.js
+++ b/clientapp/models/stats.js
@@ -1,0 +1,22 @@
+var HumanModel = require('human-model');
+
+module.exports = HumanModel.define({
+  urlRoot: function () {
+    return '/api/user/' + this.userId + '/stats';
+  },
+  props: {
+    userId: {
+      type: 'string',
+      required: true
+    },
+    earned: {
+      type: 'number'
+    },
+    favorited: {
+      type: 'number'
+    },
+    pledged: {
+      type: 'number'
+    }
+  }
+});

--- a/clientapp/router.js
+++ b/clientapp/router.js
@@ -5,6 +5,7 @@ var Achievements = require('./models/achievements');
 var Requirements = require('./models/requirements');
 var Note = require('./models/note');
 var Notes = require('./models/notes');
+var Stats = require('./models/stats');
 var LandingView = require('./views/pages/landing');
 var BadgePage = require('./views/pages/badge');
 var PathwayPage = require('./views/pages/pathway');
@@ -145,6 +146,9 @@ module.exports = Backbone.Router.extend({
   },
 
   showDashboard: function () {
+    var stats = new Stats({
+      userId: window.app.currentUser._id
+    });
     var backpack = new Achievements([], {
       pageSize: 4,
       source: Achievements.BACKPACK
@@ -157,9 +161,9 @@ module.exports = Backbone.Router.extend({
       pageSize: 4,
       source: Achievements.PLEDGED
     });
-    $.when(backpack.fetch(), wishlist.fetch(), pathways.fetch()).done(function () {
+    $.when(stats.fetch(), backpack.fetch(), wishlist.fetch(), pathways.fetch()).done(function () {
       app.renderPage(new DashboardPage({
-        model: window.app,
+        model: stats,
         sources: {
           backpack: backpack,
           wishlist: wishlist,

--- a/clientapp/templates/pages/dashboard.html
+++ b/clientapp/templates/pages/dashboard.html
@@ -13,15 +13,15 @@
         <ul class="dashboard-stats">
           <li>
             <img src="/static/dashboard/icoDashboardPathway.svg">
-            <p class="icon-length">{{pathways.models.length}} Pathway{% if pathways.models.length > 1 %}s{% endif %}</p>
+            <p class="icon-length">{{stats.pledged}} Pathway{% if pathways.models.length > 1 %}s{% endif %}</p>
           </li>
           <li>
             <img src="static/dashboard/icoDashboardBadge.svg">
-            <p class="icon-length">{{backpack.models.length}} Earned</p>
+            <p class="icon-length">{{stats.earned}} Earned</p>
           </li>
           <li>
             <img src="/static/dashboard/icoDashboardFavorited.svg">
-            <p class="icon-length">{{wishlist.models.length}} Favorited</p>
+            <p class="icon-length">{{stats.favorited}} Favorited</p>
           </li>
         </ul>
       </div>
@@ -29,19 +29,19 @@
   </section>
   <div class="row text-center page-body-rounded">
     <div class="small-12 columns">
-      <h2>{{pathways.models.length}} Pathway{% if pathways.models.length > 1 %}s{% endif %}</h2>
+      <h2>{{stats.pledged}} Pathway{% if pathways.models.length > 1 %}s{% endif %}</h2>
       <div id="pathwayPanel" class="js-pathway-items">
       </div>
 
       <hr class="full-length-hr">
 
-      <h2>{{backpack.models.length}} Earned</h2>
+      <h2>{{stats.earned}} Earned</h2>
       <div id="backpackPanel" class="js-backpack-items">
       </div>
 
       <hr class="full-length-hr">
 
-      <h2>{{wishlist.models.length}} Favorited</h2>
+      <h2>{{stats.favorited}} Favorited</h2>
       <div id="wishlistPanel" class="js-wishlist-items">
       </div>
     </div>

--- a/clientapp/views/pages/dashboard.js
+++ b/clientapp/views/pages/dashboard.js
@@ -11,9 +11,7 @@ module.exports = HumanView.extend({
   render: function () {
     this.renderAndBind({
       currentUser: window.app.currentUser,
-      backpack: this.sources.backpack,
-      wishlist: this.sources.wishlist,
-      pathways: this.sources.pathways
+      stats: this.model
     });
 
     var backpackList = new ListingView({collection: this.sources.backpack});


### PR DESCRIPTION
Adds an endpoint to pull real stats. Since the frontend collections only know about a fraction of the total number of objects they could contain at any time (unless the user has less than a page-worth of everything) counting that way doesn't work.

I think this is also a good first step towards more interesting stats, for what it's worth, since the server could do more interesting calculations/analytics at this endpoint.
