### PR TITLE
typos in about page fixed

### DIFF
--- a/clientapp/templates/pages/static/help.html
+++ b/clientapp/templates/pages/static/help.html
@@ -5,10 +5,10 @@
       <h2>About Discover</h2>
 
       <h3>How do you find your dream job?</h3>
-      <p>When you have incredibly varied strengths and interests, deciding on a career can be hard. Cool jobs often seem unattainable, and opportunities exist that you might not even know about. Mozilla's Discover project helps you identify great careers by profiling the learning experiences of working professionals, then allowing you map your own path to a rewarding job tailored to your skills and interests.</p>
+      <p>When you have incredibly varied strengths and interests, deciding on a career can be hard. Cool jobs often seem unattainable, and opportunities exist that you might not even know about. Mozilla's Discover project helps you identify great careers by profiling the learning experiences of working professionals, then allowing you to map your own path to a rewarding job tailored to your skills and interests.</p>
 
       <h3>Your skills tell your story</h3>
-      <p>Discover is a tool prototype that connects <a href="http://openbadges.org/" target="_blank">Open Badges</a> for  your interests, education, experiences and personality traits. Combined, these paint a picture of the skills you have -- and where you need to grow -- to apply for your dream job, volunteer position or  learning opportunity.</p>
+      <p>Discover is a tool prototype that connects <a href="http://openbadges.org/" target="_blank">Open Badges</a>  to your interests, education, experiences and personality traits. Combined, these paint a picture of the skills you have -- and where you need to grow -- to apply for your dream job, volunteer position or  learning opportunity.</p>
 
       <h3>Get inspired by real professionals</h3>
       <p>Discover features real people working in great careers to show how diverse (and sometimes unexpected) skills can lead to awesome opportunities. Browse the experiences of these real-life professionals to see what it takes to land a fantastic job - you might be surprised by what you find!</p>


### PR DESCRIPTION
changes made as per:

<chloe> 1) About Page
<chloe> First paragraph ==> then allowing you map your own path to a rewarding job tailored to your skills and interests. SHOUL BE then allowing you to map your own path to a rewarding job tailored to your skills and interests.
chloe> 2) Discover is a tool prototype that connects http://openbadges.org/ for your interests, education, experiences and personality traits SHOULD BE Discover is a tool prototype that connects http://openbadges.org/ to your interests, education, experiences and personality traits
